### PR TITLE
add raw GCV output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.RHistory


### PR DESCRIPTION
1792 specimens processed through Google Cloud Vision in December 2019, using builtin/legacy_20190601
8 specimens threw errors because of GCV limits and therefore have no GCV results